### PR TITLE
feat: surface scan warnings and set up pytest-cov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 output/
 docs/security/audits/
 
+# Coverage reports
+htmlcov/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,27 @@
+[pytest]
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+testpaths = tests
+
+addopts =
+    -v
+    --strict-markers
+    --tb=short
+    --cov=src
+    --cov-report=term-missing
+    --cov-report=html:htmlcov
+    --cov-branch
+
+[coverage:run]
+source = src
+omit =
+    */tests/*
+    */__pycache__/*
+    */site-packages/*
+
+[coverage:report]
+precision = 2
+show_missing = True
+skip_covered = False

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,2 @@
+
+python3 src/cloud_duplicate_analyzer.py --output-dir output/ "Google Drive:~/Google Drive/Documents" "DropBox:~/Dropbox/Documents" "OneDrive:~/OneDrive/Documents"

--- a/src/cloud_duplicate_analyzer.py
+++ b/src/cloud_duplicate_analyzer.py
@@ -122,15 +122,25 @@ def fmt_ts(ts: float) -> str:
 
 # ─────────────────────────────────────────────────────── scanning ──
 
-def scan_directory(root: Path, skip_hidden: bool) -> list[dict]:
-    """Return a list of file records for all files under root.
+def scan_directory(root: Path, skip_hidden: bool) -> tuple[list[dict], list[str]]:
+    """Return (records, warnings) for all files under root.
 
     Regular file records contain: rel_path, name, name_orig, size, mtime, full_path, folder, is_symlink=False, symlink_target=None.
     Symlink records contain: rel_path, name, name_orig, size=-1, mtime=0.0, full_path, folder, is_symlink=True, symlink_target (str or None).
     Symlinks are detected with Path.is_symlink() and compared by target path, not content.
+
+    Warnings are generated for:
+    - Permission errors encountered during directory traversal (e.g., macOS Full Disk Access not granted)
+    - Empty scan results (0 files found — may indicate a permissions issue or genuinely empty directory)
     """
     records = []
-    for dirpath, dirnames, filenames in os.walk(root):
+    warnings = []
+    walk_errors = []
+
+    def _on_walk_error(err):
+        walk_errors.append(err)
+
+    for dirpath, dirnames, filenames in os.walk(root, onerror=_on_walk_error):
         if skip_hidden:
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
             filenames = [f for f in filenames if not f.startswith(".")]
@@ -173,7 +183,12 @@ def scan_directory(root: Path, skip_hidden: bool) -> list[dict]:
                     "is_symlink": False,
                     "symlink_target": None,
                 })
-    return records
+
+    for err in walk_errors:
+        warnings.append(f"Permission denied: {err}")
+    if not records and not walk_errors:
+        warnings.append(f"0 files found in {root} — directory may be empty or inaccessible")
+    return records, warnings
 
 
 # ─────────────────────────────────────────────────────── matching ──
@@ -265,9 +280,15 @@ def analyze(dirs: list[tuple[str, Path]], mtime_fuzz: float, use_checksum: bool,
 
     print("Scanning directories …")
     scanned = {}
+    scan_warnings: dict[str, list[str]] = {}
     for label, path in dirs:
         print(f"  [{label}]  {path}")
-        scanned[label] = scan_directory(path, skip_hidden)
+        records, warnings = scan_directory(path, skip_hidden)
+        scanned[label] = records
+        if warnings:
+            scan_warnings[label] = warnings
+            for w in warnings:
+                print(f"  ⚠  {label}: {w}", file=sys.stderr)
         print(f"           {len(scanned[label]):,} files found")
 
     # Build name+size indexes per directory
@@ -676,6 +697,7 @@ def analyze(dirs: list[tuple[str, Path]], mtime_fuzz: float, use_checksum: bool,
         "labels": labels,
         "dirs": {label: str(path) for label, path in dirs},
         "total_files": {label: len(recs) for label, recs in scanned.items()},
+        "scan_warnings": scan_warnings,
         "duplicate_groups": duplicate_groups,
         "conflict_groups":        conflict_groups,
         "symlinks":               symlinks,
@@ -833,6 +855,20 @@ Comparing {n} directories</p>
                      f'<td><code>{html.escape(result["dirs"][label])}</code></td>'
                      f'<td>{result["total_files"][label]:,}</td></tr>')
     parts.append("</table>")
+
+    # scan warnings banner
+    scan_warnings = result.get("scan_warnings", {})
+    if scan_warnings:
+        parts.append('<div style="background:#f8d7da; color:#721c24; border:1px solid #f5c6cb; '
+                     'border-radius:6px; padding:12px 16px; margin:16px 0;">')
+        parts.append('<strong>⚠ Scan Warnings</strong><ul style="margin:8px 0 0 0; padding-left:20px;">')
+        for label, warnings in scan_warnings.items():
+            for w in warnings:
+                parts.append(f'<li><strong>{html.escape(label)}:</strong> {html.escape(w)}</li>')
+        parts.append('</ul><p style="margin:8px 0 0 0; font-size:12px;">'
+                     'Results below may be incomplete. On macOS, grant Full Disk Access to your '
+                     'terminal app in System Settings → Privacy &amp; Security → Full Disk Access.</p>')
+        parts.append('</div>')
 
     # ── section 2: duplicate summary ──
     parts.append("<h2>2. Duplicate File Summary</h2>")
@@ -1450,6 +1486,14 @@ def main():
     print(f"\n  Folder relationships:")
     for rel, cnt in sorted(rc.items()):
         print(f"    {rel:20s}: {cnt}")
+    scan_warnings = result.get("scan_warnings", {})
+    if scan_warnings:
+        print(f"\n  ⚠  SCAN WARNINGS — results may be incomplete:")
+        for label, warnings in scan_warnings.items():
+            for w in warnings:
+                print(f"    {label}: {w}")
+        print(f"  On macOS, grant Full Disk Access to your terminal app in "
+              f"System Settings → Privacy & Security → Full Disk Access.")
 
 
 if __name__ == "__main__":

--- a/tests/test_cloud_duplicate_analyzer.py
+++ b/tests/test_cloud_duplicate_analyzer.py
@@ -260,7 +260,7 @@ class TestSymlinkDetection(unittest.TestCase):
         symlink_path.symlink_to(regular_file)
 
         # Scan directory with symlink
-        records = cda.scan_directory(Path(self.tmp) / "b", skip_hidden=False)
+        records, _ = cda.scan_directory(Path(self.tmp) / "b", skip_hidden=False)
 
         # Find the symlink record
         symlink_record = next((r for r in records if r["name_orig"] == "link.txt"), None)
@@ -283,7 +283,7 @@ class TestSymlinkDetection(unittest.TestCase):
         symlink_path.symlink_to(Path(self.tmp) / "nonexistent_target.txt")
 
         # Must not crash
-        records = cda.scan_directory(Path(self.tmp) / "scan_dir", skip_hidden=False)
+        records, _ = cda.scan_directory(Path(self.tmp) / "scan_dir", skip_hidden=False)
 
         dangling = next((r for r in records if r["name_orig"] == "dangling.txt"), None)
         assert dangling is not None
@@ -298,7 +298,7 @@ class TestSymlinkDetection(unittest.TestCase):
         """Verify regular files have is_symlink=False."""
         make_file(self.tmp, "a/regular.txt", b"content")
 
-        records = cda.scan_directory(Path(self.tmp) / "a", skip_hidden=False)
+        records, _ = cda.scan_directory(Path(self.tmp) / "a", skip_hidden=False)
 
         regular_record = next((r for r in records if r["name_orig"] == "regular.txt"), None)
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -93,7 +93,7 @@ class TestScanDirectory(unittest.TestCase):
     def test_skip_hidden_files(self):
         make_file(self.tmp, "visible.txt", b"v")
         make_file(self.tmp, ".hidden.txt", b"h")
-        records = cda.scan_directory(Path(self.tmp), skip_hidden=True)
+        records, _ = cda.scan_directory(Path(self.tmp), skip_hidden=True)
         names = [r["name_orig"] for r in records]
         self.assertIn("visible.txt", names)
         self.assertNotIn(".hidden.txt", names)
@@ -101,7 +101,7 @@ class TestScanDirectory(unittest.TestCase):
     def test_include_hidden_files(self):
         make_file(self.tmp, "visible.txt", b"v")
         make_file(self.tmp, ".hidden.txt", b"h")
-        records = cda.scan_directory(Path(self.tmp), skip_hidden=False)
+        records, _ = cda.scan_directory(Path(self.tmp), skip_hidden=False)
         names = [r["name_orig"] for r in records]
         self.assertIn("visible.txt", names)
         self.assertIn(".hidden.txt", names)
@@ -109,7 +109,7 @@ class TestScanDirectory(unittest.TestCase):
     def test_skip_hidden_dirs(self):
         make_file(self.tmp, ".hidden_dir/file.txt", b"h")
         make_file(self.tmp, "visible_dir/file.txt", b"v")
-        records = cda.scan_directory(Path(self.tmp), skip_hidden=True)
+        records, _ = cda.scan_directory(Path(self.tmp), skip_hidden=True)
         folders = [r["folder"] for r in records]
         self.assertNotIn(".hidden_dir", folders)
         self.assertIn("visible_dir", folders)
@@ -117,7 +117,7 @@ class TestScanDirectory(unittest.TestCase):
     def test_ds_store_skipped(self):
         make_file(self.tmp, ".DS_Store", b"junk")
         make_file(self.tmp, "real.txt", b"data")
-        records = cda.scan_directory(Path(self.tmp), skip_hidden=False)
+        records, _ = cda.scan_directory(Path(self.tmp), skip_hidden=False)
         names = [r["name_orig"] for r in records]
         self.assertNotIn(".DS_Store", names)
         self.assertIn("real.txt", names)
@@ -126,7 +126,7 @@ class TestScanDirectory(unittest.TestCase):
         target = make_file(self.tmp, "target.txt", b"content")
         link = Path(self.tmp) / "link.txt"
         link.symlink_to(target)
-        records = cda.scan_directory(Path(self.tmp), skip_hidden=False)
+        records, _ = cda.scan_directory(Path(self.tmp), skip_hidden=False)
         link_rec = next(r for r in records if r["name_orig"] == "link.txt")
         self.assertTrue(link_rec["is_symlink"])
         self.assertEqual(link_rec["size"], -1)
@@ -135,13 +135,49 @@ class TestScanDirectory(unittest.TestCase):
 
     def test_regular_file_fields(self):
         make_file(self.tmp, "sub/file.txt", b"hello", mtime=1000.0)
-        records = cda.scan_directory(Path(self.tmp), skip_hidden=True)
+        records, _ = cda.scan_directory(Path(self.tmp), skip_hidden=True)
         rec = next(r for r in records if r["name_orig"] == "file.txt")
         self.assertFalse(rec["is_symlink"])
         self.assertIsNone(rec["symlink_target"])
         self.assertEqual(rec["size"], 5)
         self.assertEqual(rec["folder"], "sub")
         self.assertEqual(rec["name"], "file.txt")  # lowercased
+
+    def test_no_warnings_for_normal_scan(self):
+        make_file(self.tmp, "file.txt", b"data")
+        _, warnings = cda.scan_directory(Path(self.tmp), skip_hidden=True)
+        self.assertEqual(warnings, [])
+
+    def test_empty_dir_warning(self):
+        empty = Path(self.tmp) / "empty"
+        empty.mkdir()
+        records, warnings = cda.scan_directory(empty, skip_hidden=True)
+        self.assertEqual(records, [])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("0 files found", warnings[0])
+
+    def test_permission_error_warning(self):
+        subdir = Path(self.tmp) / "locked"
+        subdir.mkdir()
+        make_file(self.tmp, "locked/secret.txt", b"data")
+        subdir.chmod(0o000)
+        try:
+            records, warnings = cda.scan_directory(Path(self.tmp), skip_hidden=False)
+            self.assertTrue(any("Permission denied" in w for w in warnings))
+        finally:
+            subdir.chmod(0o755)
+
+    def test_permission_error_on_root_dir(self):
+        root = Path(self.tmp) / "noaccess"
+        root.mkdir()
+        make_file(self.tmp, "noaccess/file.txt", b"data")
+        root.chmod(0o000)
+        try:
+            records, warnings = cda.scan_directory(root, skip_hidden=False)
+            self.assertEqual(records, [])
+            self.assertTrue(any("Permission denied" in w for w in warnings))
+        finally:
+            root.chmod(0o755)
 
 
 # ── _file_sym ────────────────────────────────────────────────────────
@@ -870,6 +906,51 @@ class TestRenderHtmlFullIntegration(_RenderHelper, unittest.TestCase):
         html = cda.render_html(r)
         self.assertIn("<!DOCTYPE html>", html)
         self.assertIn("</html>", html)
+
+
+class TestScanWarningsInReport(_RenderHelper, unittest.TestCase):
+    """Verify scan_warnings flow into analyze result and render_html output."""
+
+    def test_scan_warnings_in_result_when_no_issues(self):
+        r = self._run(
+            [("a.txt", b"data", 1000.0)],
+            [("b.txt", b"data", 1000.0)],
+        )
+        self.assertEqual(r["scan_warnings"], {})
+
+    def test_scan_warnings_in_html_when_present(self):
+        r = self._run(
+            [("a.txt", b"data", 1000.0)],
+            [("b.txt", b"data", 1000.0)],
+        )
+        r["scan_warnings"] = {"DropBox": ["Permission denied: [Errno 1] Operation not permitted: '/Users/me/Dropbox'"]}
+        r["mtime_fuzz"] = 5
+        html = cda.render_html(r)
+        self.assertIn("Scan Warnings", html)
+        self.assertIn("DropBox", html)
+        self.assertIn("Permission denied", html)
+        self.assertIn("Full Disk Access", html)
+
+    def test_scan_warnings_not_in_html_when_absent(self):
+        r = self._run(
+            [("a.txt", b"data", 1000.0)],
+            [("b.txt", b"data", 1000.0)],
+        )
+        r["mtime_fuzz"] = 5
+        html = cda.render_html(r)
+        self.assertNotIn("Scan Warnings", html)
+
+    def test_empty_dir_produces_warning_in_analyze(self):
+        dir_a = Path(self.tmp) / "populated"
+        dir_b = Path(self.tmp) / "empty_dir"
+        dir_b.mkdir(parents=True, exist_ok=True)
+        make_file(dir_a, "file.txt", b"data", 1000.0)
+        r = cda.analyze(
+            [("Full", dir_a), ("Empty", dir_b)],
+            mtime_fuzz=5.0, use_checksum=True, skip_hidden=True,
+        )
+        self.assertIn("Empty", r["scan_warnings"])
+        self.assertTrue(any("0 files found" in w for w in r["scan_warnings"]["Empty"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Scan warnings**: scan_directory now captures os.walk permission errors and empty-dir conditions, surfacing them as a red banner in HTML, in JSON under scan_warnings, and on stderr/stdout. This prevents silent 0-file scans when macOS Full Disk Access is not granted.
- **pytest-cov**: Added pytest.ini with coverage config (branch coverage, htmlcov/ output, term-missing)
- **scripts/test.sh**: Convenience script to run the analyzer against cloud storage dirs

## Test plan
- [x] All existing tests updated for new scan_directory return signature
- [x] New tests: empty dir warning, permission error warning, root dir permission error, warnings in HTML render
- [x] Run python3 -m pytest tests/ -v -- 146 passed, 96% coverage
- [x] Run scripts/test.sh without Full Disk Access -- warning banner appears in report

Generated with [Claude Code](https://claude.com/claude-code)